### PR TITLE
Add support for PDF output and per-request format customization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+1.1.0 / ??-??-2017
+==================
+
+* Add PDF output support
+* Add support to customize the output format with a `format` request parameter
+
+1.0.0 / ??-??-2017
+==================
+
+* Initial public release

--- a/README.md
+++ b/README.md
@@ -19,27 +19,30 @@ npm install screenie-server
 ```
 
 Then request a screenshot of an URL using the `url` query parameter:
-`http://localhost:3000/?url=http://google.com/`
+`http://localhost:3000/?url=http://google.com/&format=jpeg`
 
-The default size of the screenshot created is 1024x768. This can be customized
-through the `width` and `height` query parameters, but will be constrained
-within 2048x2048.
+The size of the screenshot can be customized through the `width` and `height`
+query parameters, but will always be constrained within 2048x2048. The default
+size used when the parameters are missing can be customized by environment
+variables:
 
-Alternatively you can customize the default size and image type using
-environment variables:
+- `SCREENIE_WIDTH`: Default width, as integer, in pixels (default `1024`).
+- `SCREENIE_HEIGHT`: Default height, as integer, in pixels (default `768`).
 
-- `SCREENIE_WIDTH`: Default width, as integer, in pixels.
-- `SCREENIE_HEIGHT`: Default height, as integer, in pixels.
-- `SCREENIE_IMAGE_TYPE`: Image type, one of `jpeg`, `png` or `gif`.
+The `format` query parameter can be used to request a specific format of the
+screenshot. The supported formats are PNG, JPEG, GIF and even PDF. You can
+also set the default format through an environment variable:
+
+- `SCREENIE_DEFAULT_FORMAT`: Default format (default `jpeg`).
 
 The PhantomJS pool can also be customized with environment variables:
 
-- `SCREENIE_POOL_MIN`: Minimum number of PhantomJS instances.
-- `SCREENIE_POOL_MAX`: Maximum number of PhantomJS instances.
+- `SCREENIE_POOL_MIN`: Minimum number of PhantomJS instances (default `2`).
+- `SCREENIE_POOL_MAX`: Maximum number of PhantomJS instances (default `10`).
 
 And lastly, of course the HTTP port can be customized:
 
-- `SCREENIE_PORT`: HTTP port, defaults to 3000.
+- `SCREENIE_PORT`: HTTP port (default `3000`).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "koa": "1.2.4",
-    "phantom-pool": "1.1.0"
+    "phantom-pool": "1.1.0",
+    "tmp": "0.0.31"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -90,7 +90,7 @@ app.use(function *(next) {
  */
 app.use(function *(next) {
     if (this.state.format === 'pdf') {
-        this.state.page.property('paperSize', {
+        yield this.state.page.property('paperSize', {
             format: 'A4',
             orientation: 'portrait',
             border: '1cm',

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const koa = require('koa');
+const tmp = require('tmp');
 const createPhantomPool = require('phantom-pool').default;
 
 const app = koa();
@@ -15,7 +16,14 @@ const imageSize = {
     width: process.env.SCREENIE_WIDTH || 1024,
     height: process.env.SCREENIE_HEIGHT || 768,
 };
-const imageType = process.env.SCREENIE_IMAGE_TYPE || 'jpeg';
+const supportedFormats = [
+    'gif',
+    'jpeg',
+    'jpg',
+    'pdf',
+    'png',
+]
+const defaultFormat = process.env.SCREENIE_DEFAULT_FORMAT || 'jpeg';
 
 /**
  * Set up a PhantomJS instance with a page and configure viewport size.
@@ -49,7 +57,7 @@ app.use(function *(next) {
     const { url } = this.request.query;
 
     if (!url) {
-        this.throw(400);
+        this.throw('No url request parameter supplied.', 400);
     }
 
     yield this.state.page.open(url)
@@ -60,22 +68,69 @@ app.use(function *(next) {
 });
 
 /**
+ * Determine the format of the output based on the `format` query parameter.
+ *
+ * The format must be among the formats supported by PhantomJS, else 400
+ * Bad Request is thrown. If no format is provided, the default is used.
+ */
+app.use(function *(next) {
+    const { format = defaultFormat } = this.request.query;
+
+    if (supportedFormats.indexOf(format.toLowerCase()) === -1) {
+        this.throw(`Format ${format} not supported.`, 400);
+    }
+
+    this.type = this.state.format = format;
+    yield next;
+});
+
+/**
+ * Set up the size of the page to render, either the paper size for PDF or
+ * clip rectangle for image formats.
+ */
+app.use(function *(next) {
+    if (this.state.format === 'pdf') {
+        this.state.page.property('paperSize', {
+            format: 'A4',
+            orientation: 'portrait',
+            border: '1cm',
+        });
+    }
+    else {
+        yield this.state.page.property('viewportSize')
+            .then(size => ({
+                top: 0,
+                left: 0,
+                width: size.width,
+                height: size.height,
+            }))
+            .then(clipRect => this.state.page.property('clipRect', clipRect));
+    }
+
+    yield next;
+});
+
+/**
  * Generate a screenshot of the loaded page.
  *
  * If successful the screenshot is sent as the response.
  */
 app.use(function *(next) {
-    yield this.state.page.property('viewportSize')
-        .then(size => ({
-            top: 0, left: 0,
-            width: size.width, height: size.height
-        }))
-        .then(clipRect => this.state.page.property('clipRect', clipRect))
-        .then(() => this.state.page.renderBase64(imageType))
-        .then((imageData) => {
-            this.type = `image/${imageType}`;
-            this.body = Buffer.from(imageData, 'base64');
-        });
+    if (this.state.format === 'pdf') {
+        const tmpFile = tmp.fileSync({ postfix: '.pdf'});
+
+        yield this.state.page.render(tmpFile.name)
+            .then(() => {
+                this.body = fs.createReadStream(tmpFile.name);
+
+                // Delete the temp file after served to client
+                this.body.on('close', () => tmpFile.removeCallback());
+            });
+    }
+    else {
+        yield this.state.page.renderBase64(this.state.format)
+            .then((imageData) => this.body = Buffer.from(imageData, 'base64'));
+    }
 });
 
 app.listen(serverPort);


### PR DESCRIPTION
A new `format` query parameter is now supported, to be able to customize
the output per request. PDF is now a supported format.