### PR TITLE
Add basic logging functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The PhantomJS pool can also be customized with environment variables:
 - `SCREENIE_POOL_MIN`: Minimum number of PhantomJS instances (default `2`).
 - `SCREENIE_POOL_MAX`: Maximum number of PhantomJS instances (default `10`).
 
+To control the level of logging that will be performed, customize the
+`SCREENIE_LOG_LEVEL` environment variable. Supported values are `error`,
+`warn`, `info`, `verbose`, `debug`, and `silly`, though only `info` and
+`verbose` are currently in use.
+
+- `SCREENIE_LOG_LEVEL`: Logging level (default `info`).
+
 And lastly, of course the HTTP port can be customized:
 
 - `SCREENIE_PORT`: HTTP port (default `3000`).

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A screenshot HTTP service using PhantomJS",
   "author": "Frode Danielsen <frode@e5r.no>",
   "keywords": [
-      "screenshot",
-      "phantomjs",
-      "koa"
+    "screenshot",
+    "phantomjs",
+    "koa"
   ],
   "main": "src/server.js",
   "bin": {
@@ -20,8 +20,8 @@
     "node": ">= 6.0.0"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/eliksir/screenie-server.git"
+    "type": "git",
+    "url": "https://github.com/eliksir/screenie-server.git"
   },
   "bugs": {
     "url": "https://github.com/eliksir/screenie-server/issues"
@@ -29,6 +29,7 @@
   "dependencies": {
     "koa": "1.2.4",
     "phantom-pool": "1.1.0",
-    "tmp": "0.0.31"
+    "tmp": "0.0.31",
+    "winston": "2.3.1"
   }
 }


### PR DESCRIPTION
Add basic logging functionality using the winston library. The level of log output can be set by customizing the `SCREENIE_LOG_LEVEL` environment variable.