### PR TITLE
Make sure all resources on a page is loaded before taking a screenshot

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -112,7 +112,9 @@ app.use(function*(next) {
 
   logger.verbose(`Attempting to load ${url}`);
 
-  yield page.goto(url).catch(() => (gotoError = true));
+  yield page
+    .goto(url, { waitUntil: 'networkidle0' })
+    .catch(() => (gotoError = true));
 
   if (gotoError) {
     this.throw(404);


### PR DESCRIPTION
By passing in `networkidle0` to the `goto` function we consider
navigation to be finished when there are no more than 0 network
connections for at least 500 ms.