### PR TITLE
Add ENV for SCREENIE_SCREENSHOT_DELAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ To open up file scheme in URL parameter:
 
 * `SCREENIE_ALLOW_FILE_SCHEME`: true (default `false`).
 
+Delay from the `load` event until the screenshot is taken. This can solve
+issues with rendering (i.e. rendering webfonts) not being complete before the
+screenshot.
+
+* `SCREENIE_SCREENSHOT_DELAY`: Time in milliseconds (default `50`).
+
 And lastly, of course the HTTP port can be customized:
 
 * `SCREENIE_PORT`: HTTP port (default `3000`).

--- a/src/server.js
+++ b/src/server.js
@@ -41,6 +41,11 @@ const pool = createPuppeteerPool({
   puppeteerArgs: Object.assign({}, chromiumArgs, chromiumExec),
 });
 
+const screenshotDelay = () =>
+  new Promise(resolve =>
+    setTimeout(resolve, process.env.SCREENIE_SCREENSHOT_DELAY | 50)
+  );
+
 logger.verbose('Created Puppeteer pool');
 
 /*
@@ -118,7 +123,8 @@ app.use(function*(next) {
   logger.verbose(`Attempting to load ${url}`);
 
   yield page
-    .goto(url, { waitUntil: 'networkidle0' })
+    .goto(url)
+    .then(screenshotDelay)
     .catch(() => (gotoError = true));
 
   if (gotoError) {


### PR DESCRIPTION
The `networkidle0` option on `goto` adds a static 500ms delay on all
requests to screenie. This is not optimal for servering many requests.
We therefore go back to use the default `waitUntil` option which is
`load` and make the delay configurable. The default is 50ms.