### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 7.6.0"
+    "node": ">=10.18.1"
   },
   "repository": {
     "type": "git",
@@ -27,9 +27,9 @@
     "url": "https://github.com/eliksir/screenie-server/issues"
   },
   "dependencies": {
-    "koa": "2.11.0",
-    "puppeteer": "1.19.0",
+    "koa": "2.13.1",
+    "puppeteer": "8.0.0",
     "puppeteer-pool": "eliksir/puppeteer-pool#v1.3.1",
-    "winston": "3.2.1"
+    "winston": "3.3.3"
   }
 }


### PR DESCRIPTION
Particularly Puppeteer has seen lots of updates since we last updated our
version of it. Mostly they've added support for Firefox, and lots of nice
new features we don't make use of yet, with no breaking changes for our
use. The main breaking change is a bump in minimum Node version, but we
are way overdo in that too anyway.

Together with Puppeteer, Koa and Winston have also received minor updates.